### PR TITLE
Fix middleware issue on rendering non HTML content

### DIFF
--- a/htmx-ai/src/middleware.ts
+++ b/htmx-ai/src/middleware.ts
@@ -17,7 +17,6 @@ export const onRequest = async (context, next) => {
   }
 
   const response = await next();
-  console.log(context.url.pathname)
   let html = await response.text();
 
   // Delete the CSS and JS from the HTML response

--- a/htmx-ai/src/middleware.ts
+++ b/htmx-ai/src/middleware.ts
@@ -10,16 +10,19 @@ not require additional JS because ... HTMX.
 const HTMX_FRAGMENT_ROUTES = ["/prompt"];
 
 export const onRequest = async (context, next) => {
+  if (
+    !HTMX_FRAGMENT_ROUTES.find((route) => context.request.url.includes(route))
+  ) {
+    return next();
+  }
+
   const response = await next();
+  console.log(context.url.pathname)
   let html = await response.text();
 
-  if (
-    HTMX_FRAGMENT_ROUTES.find((route) => context.request.url.includes(route))
-  ) {
-    // Delete the CSS and JS from the HTML response
-    html = html.replace(/<style type\=\"text\/css\"(.*)<\/style>/s, "");
-    html = html.replace(/<script(.*)<\/script>/gm, "");
-  }
+  // Delete the CSS and JS from the HTML response
+  html = html.replace(/<style type\=\"text\/css\"(.*)<\/style>/s, "");
+  html = html.replace(/<script(.*)<\/script>/gm, "");
 
   return new Response(html, {
     status: 200,


### PR DESCRIPTION
since this middleware calls `response.text()` before doing the check, the requests that resolve to non html content (eg. images) can fail